### PR TITLE
remove duplicate import from courses

### DIFF
--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -9,7 +9,6 @@ import { Label } from "@/components/ui/label"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Column, ColumnDef, ColumnFiltersState, flexRender, getCoreRowModel, getFilteredRowModel, getPaginationRowModel, getSortedRowModel, SortingState, useReactTable, VisibilityState } from "@tanstack/react-table"
 import { ArrowUpDown, MoreHorizontal } from "lucide-react"
-import React from "react"
 import React, { FormEvent } from "react"
 import { toast } from "sonner"
 


### PR DESCRIPTION
## Remove duplicate import of React from the `/courses`

### Before 
![image](https://github.com/user-attachments/assets/3bd3be27-61a0-47b5-8ae1-bd140751509f)

### Now
![image](https://github.com/user-attachments/assets/7246f829-59e7-4627-acb1-5e511cda5999)
